### PR TITLE
Don't override options.juice.webResources.relativeTo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ TplEmails.prototype.render = function(templateName, options, cb) {
         options.url = fileUrl;
         options.juice = options.juice || {};
         options.juice.webResources = options.juice.webResources || {};
-        options.juice.webResources.relativeTo = path.dirname(path.relative(process.cwd(), fileUrl));
+        options.juice.webResources.relativeTo = options.juice.webResources.relativeTo || path.dirname(path.relative(process.cwd(), fileUrl));
 
         juice.juiceResources($.html(), options.juice, function(err, htmlInlined) {
             if (err) return cb(err);


### PR DESCRIPTION
You can pass in a `juice` object into the constructor to configure juice, but if you pass in your own `relativeTo` path, it will always get erased.  This change allows it to persist unless it is falsey.  

See #2 for context.

By adding this change and then doing the following:

``` javascript
var root = path.join(__dirname, 'templates'),
  env = new nunjucks.Environment(new nunjucks.FileSystemLoader(root)),
  emails = new TplEmails({
    render: env.render.bind(env),
    juice: { webResources: { relativeTo: root } }
  });
```

I was able to resolve the path issues I was seeing in #2.  It is kind of a hassle to go to all this trouble, but that appears to be the way Juice works with its [web-resource-inliner](https://github.com/jrit/web-resource-inliner)

I'm unsure really if `path.dirname(path.relative(process.cwd(), fileUrl))` is the way to go here, but at least this won't break anything
